### PR TITLE
relax HTML::Pipeline dependency

### DIFF
--- a/markdown_proofer.gemspec
+++ b/markdown_proofer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'github-markdown', '~> 0.6.5'
-  spec.add_dependency 'html-pipeline', '~> 1.8'
+  spec.add_dependency 'html-pipeline', '< 2'
   spec.add_dependency 'html-proofer', '~> 0.6.7'
 
   spec.add_development_dependency 'bundler', '~> 1.5'


### PR DESCRIPTION
Basic usage hasn't changed:

https://github.com/jch/html-pipeline/tree/v0.0.4#usage
