### PR TITLE
should_receive syntax update

### DIFF
--- a/spec/markdown_proofer_spec.rb
+++ b/spec/markdown_proofer_spec.rb
@@ -37,7 +37,7 @@ describe MarkdownProofer, vcr: vcr_options do
 
   describe '#run' do
     it "passes options to HTML::Proofer" do
-      HTML::Proofer.should_receive(:new).with(anything, ext: 'htm').and_call_original
+      expect(HTML::Proofer).to receive(:new).with(anything, ext: 'htm').and_call_original
 
       path = fixture_path('working_link.md')
       proofer = MarkdownProofer.new(path: path, html_proofer: {ext: 'htm'})

--- a/spec/markdown_proofer_spec.rb
+++ b/spec/markdown_proofer_spec.rb
@@ -46,7 +46,7 @@ describe MarkdownProofer, vcr: vcr_options do
 
     it "works for relative links" do
       proofer = MarkdownProofer.new(path: fixture_path('relative_link.md'))
-      expect(proofer.run).to be_true
+      expect(proofer.run).to eq(true)
     end
 
     it "complains for files with broken links" do
@@ -58,12 +58,12 @@ describe MarkdownProofer, vcr: vcr_options do
 
     it "returns true for no broken links" do
       proofer = MarkdownProofer.new(path: fixture_path('working_link.md'))
-      expect(proofer.run).to be_true
+      expect(proofer.run).to eq(true)
     end
 
     it "returns false for broken links" do
       proofer = MarkdownProofer.new(path: fixture_path)
-      expect(proofer.run).to be_false
+      expect(proofer.run).to eq(false)
     end
 
     it "can be executed multiple times" do


### PR DESCRIPTION
Hi again, 

Per [this article](https://relishapp.com/rspec/rspec-expectations/docs/syntax-configuration#explicitly-enable-both-syntaxes), `should_receive` is depreciated. I've updated [line 40](https://github.com/afeld/markdown_proofer/blob/master/spec/markdown_proofer_spec.rb#L40) in  [spec/markdown_proofer_spec.rb](https://github.com/afeld/markdown_proofer/blob/master/spec/markdown_proofer_spec.rb) to reflect the new syntax. See also [this blog post](http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/).

Thanks,
Andy
